### PR TITLE
alert channel on error

### DIFF
--- a/BDminer.py
+++ b/BDminer.py
@@ -422,6 +422,10 @@ finally:
     mydb.close()
 print('Finished. Beatdowns are up to date.')
 logging.info("BDminer execution complete for region " + db)
+
+if qc == 0:
+    pm_log_text += "<!channel> \n"
+    
 pm_log_text += "End of PAXminer hourly run"
 try:
     slack.chat_postMessage(channel='paxminer_logs', text=pm_log_text)


### PR DESCRIPTION
If there is an error processing a backblast, this will add @channel to the message in paxminer_logs. In my case, I have notifications muted for paxminer_logs so that I don't get notified every hour. Which also means I don't see right away when there is an error. Flagging @channel would allow any members of the log channel (i.e. admins) to be notified if there is an issue.