### PR TITLE
Link to post

### DIFF
--- a/BDminer.py
+++ b/BDminer.py
@@ -357,7 +357,7 @@ try:
                     q_error_text += "You can also check for other common mistakes that cause errors - such as spaces at the beginning of Date:, Q:, AO:, or other lines, or even other messages you may have posted that begin with the word Backblast."
                 if send_q_msg > 0:
                     print(backblast)
-                    slack.chat_postMessage(channel=user_id, text=q_error_text)
+                    slack.chat_postMessage(channel=user_id, unfurl_links=False, text=q_error_text)
 
                 #Add the Q to the bd_attendance table as some Q's are forgetting to add themselves to the PAX line
                 if qc == 1:
@@ -426,7 +426,7 @@ print('Finished. Beatdowns are up to date.')
 logging.info("BDminer execution complete for region " + db)
 pm_log_text += "End of PAXminer hourly run"
 try:
-    slack.chat_postMessage(channel='paxminer_logs', text=pm_log_text)
+    slack.chat_postMessage(channel='paxminer_logs', unfurl_links=False, text=pm_log_text)
 except:
     print("Slack log message error - not posted")
     pass

--- a/BDminer.py
+++ b/BDminer.py
@@ -297,13 +297,15 @@ try:
             user_id = row['user_id']
             fngs = row['fngs']
             ao_name = row['ao_name']
+            msg_link = slack.chat_getPermalink(channel=ao_id, message_ts=timestamp)["permalink"]
             val = (timestamp, ts_edited, ao_id, bd_date, q_user_id, coq_user_id, pax_count, backblast, fngs)
             # for Slackblast users, set the user_id as the Q
             appnames = ['slackblast', 'Slackblast']
             if user_name in appnames:
                 user_id = q_user_id
                 user_name = 'Q'
-            q_error_text = "Hey " + user_name + " - I see a backblast you posted on " + msg_date + " at <#" + ao_id + ">. Here's what happened when I tried to process it: \n"
+            q_error_text = "Hey " + user_name + " - I see a backblast you posted on " + msg_date + " at <#" + ao_id + "> (<" + msg_link + "|link>). Here's what happened when I tried to process it: \n"
+            pm_log_text += "- Processing <" + msg_link + "|this> backblast."
             if msg_date > cutoff_date:
                 if q_user_id == 'NA':
                     logging.warning("Q error for AO: %s, Date: %s, backblast from Q %s (ID %s) not imported", ao_id, msg_date, user_name, user_id)


### PR DESCRIPTION
This will add a link to both the log messages and the q messages. The link is to the backblast being posted. The link will appear in both log and q messages for success and failures. I also disabled unfurling so a preview of the backblast won't show up under the message can cause clutter.