### PR TITLE
Bug Fix - Initiate Channel DF with columns

### DIFF
--- a/PAX_BD_Miner.py
+++ b/PAX_BD_Miner.py
@@ -127,7 +127,8 @@ finally:
     print('Looking for new backblasts from Slack...')
 
 # Get all channel conversation
-messages_df = pd.DataFrame([]) #creates an empty dataframe to append to
+# messages_df = pd.DataFrame([]) #creates an empty dataframe to append to
+messages_df = pd.DataFrame([], columns={'user_id', 'message_type', 'timestamp', 'ts_edited', 'text', 'channel_id'}) #creates an empty dataframe to append to
 for id in channels_df['channel_id']:
     data = ''
     pages = 1


### PR DESCRIPTION
When a region doesn't have any channels marked as backblast and with messages posted to them. Don't blow up the script, initiate the dataframe with the appropriate columns.

Previous Behavior:
Paxminer would run for a region, not have any messages to process from any channels, and exit early in its process.

```
Traceback (most recent call last):
  File "/Users/willfarrell/dev/f3/PAXminer/PAX_BD_Miner.py", line 172, in <module>
    for ts in messages_df['timestamp']:
  File "/Users/willfarrell/Library/Python/3.9/lib/python/site-packages/pandas/core/frame.py", line 3506, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/Users/willfarrell/Library/Python/3.9/lib/python/site-packages/pandas/core/indexes/base.py", line 3623, in get_loc
    raise KeyError(key) from err
KeyError: 'timestamp'
```

Current Behavior:
Paxminer still runs for that region, finishes its process without exiting.