### PR TITLE
Fix column order inconsistency in DataFrame creation

### DIFF
--- a/backblast_scraping/PAX_BD_Miner.py
+++ b/backblast_scraping/PAX_BD_Miner.py
@@ -115,7 +115,7 @@ try:
         sql = "SELECT channel_id, ao FROM aos WHERE backblast = 1 AND archived = 0"
         cursor.execute(sql)
         channels = cursor.fetchall()
-        channels_df = pd.DataFrame(channels, columns={'channel_id', 'ao'})
+        channels_df = pd.DataFrame(channels, columns=['channel_id', 'ao'])
 finally:
     print('Pulling current beatdown records...')
 
@@ -130,7 +130,7 @@ finally:
 
 # Get all channel conversation
 # messages_df = pd.DataFrame([]) #creates an empty dataframe to append to
-messages_df = pd.DataFrame([], columns={'user_id', 'message_type', 'timestamp', 'ts_edited', 'text', 'channel_id'}) #creates an empty dataframe to append to
+messages_df = pd.DataFrame([], columns=['user_id', 'message_type', 'timestamp', 'ts_edited', 'text', 'channel_id']) #creates an empty dataframe to append to
 for id in channels_df['channel_id']:
     data = ''
     pages = 1

--- a/backblast_scraping/PAXminer_Daily_Execution.py
+++ b/backblast_scraping/PAXminer_Daily_Execution.py
@@ -47,7 +47,7 @@ try:
         sql = "SELECT * from paxminer.regions WHERE active = 1 AND region REGEXP '^[" + region_regex + "]'"
         cursor.execute(sql)
         regions = cursor.fetchall()
-        regions_df = pd.DataFrame(regions, columns={'region', 'slack_token', 'schema_name'})
+        regions_df = pd.DataFrame(regions, columns=['region', 'slack_token', 'schema_name'])
 finally:
     print('Getting list of regions that use PAXminer...')
 

--- a/backblast_scraping/PAXminer_Manual_Execution.py
+++ b/backblast_scraping/PAXminer_Manual_Execution.py
@@ -39,7 +39,7 @@ try:
         sql = "SELECT * FROM paxminer.regions where region = 'Mobile'" # <-- Update this for whatever region is being tested
         cursor.execute(sql)
         regions = cursor.fetchall()
-        regions_df = pd.DataFrame(regions, columns={'region', 'slack_token', 'schema_name'})
+        regions_df = pd.DataFrame(regions, columns=['region', 'slack_token', 'schema_name'])
 finally:
     print('Getting list of regions that use PAXminer...')
 

--- a/database_management/PAXminer_SlackUserUpdate.py
+++ b/database_management/PAXminer_SlackUserUpdate.py
@@ -32,7 +32,7 @@ def database_management_update():
             sql = "SELECT * FROM paxminer.regions where active = 1"
             cursor.execute(sql)
             regions = cursor.fetchall()
-            regions_df = pd.DataFrame(regions, columns={'region', 'slack_token', 'schema_name'})
+            regions_df = pd.DataFrame(regions, columns=['region', 'slack_token', 'schema_name'])
     finally:
         logging.info('Getting list of regions that use PAXminer...')
 

--- a/monthly_charts/LeaderboardByAO_Charter.py
+++ b/monthly_charts/LeaderboardByAO_Charter.py
@@ -66,7 +66,7 @@ try:
         sql = "SELECT ao, channel_id FROM aos WHERE backblast = 1 and archived = 0"
         cursor.execute(sql)
         aos = cursor.fetchall()
-        aos_df = pd.DataFrame(aos, columns={'ao', 'channel_id'})
+        aos_df = pd.DataFrame(aos, columns=['ao', 'channel_id'])
 finally:
     print('Now pulling all beatdown records... Stand by...')
 
@@ -92,7 +92,7 @@ for index, row in aos_df.iterrows():
             val = (thismonth, yearnum, ao)
             cursor.execute(sql, val)
             posts = cursor.fetchall()
-            posts_df = pd.DataFrame(posts, columns={'PAX', 'Posts'})
+            posts_df = pd.DataFrame(posts, columns=['PAX', 'Posts'])
     finally:
         print('Now pulling all posting records for', ao, '... Stand by...')
 
@@ -130,7 +130,7 @@ for index, row in aos_df.iterrows():
             val = (yearnum, ao)
             cursor.execute(sql, val)
             posts = cursor.fetchall()
-            posts_df = pd.DataFrame(posts, columns={'PAX', 'Posts'})
+            posts_df = pd.DataFrame(posts, columns=['PAX', 'Posts'])
     finally:
         print('Now pulling all posting records for', ao, '... Stand by...')
     if not posts_df.empty:

--- a/monthly_charts/Leaderboard_Charter.py
+++ b/monthly_charts/Leaderboard_Charter.py
@@ -70,7 +70,7 @@ try:
         val = (thismonth, yearnum)
         cursor.execute(sql, val)
         posts = cursor.fetchall()
-        posts_df = pd.DataFrame(posts, columns={'PAX', 'UniqueAOs', 'Posts'})
+        posts_df = pd.DataFrame(posts, columns=['PAX', 'UniqueAOs', 'Posts'])
 finally:
     print('Now pulling all posting records for', region, '... Stand by...')
 
@@ -98,7 +98,7 @@ try:
         val = (yearnum)
         cursor.execute(sql, val)
         posts = cursor.fetchall()
-        posts_df = pd.DataFrame(posts, columns={'PAX', 'UniqueAOs', 'Posts'})
+        posts_df = pd.DataFrame(posts, columns=['PAX', 'UniqueAOs', 'Posts'])
 finally:
     print('Now pulling all posting records for', region, '... Stand by...')
 

--- a/monthly_charts/Qcharter.py
+++ b/monthly_charts/Qcharter.py
@@ -55,7 +55,7 @@ try:
         sql = "SELECT ao, channel_id FROM aos WHERE backblast = 1 and archived = 0"
         cursor.execute(sql)
         aos = cursor.fetchall()
-        aos_df = pd.DataFrame(aos, columns={'ao', 'channel_id'})
+        aos_df = pd.DataFrame(aos, columns=['ao', 'channel_id'])
 finally:
     print('Now pulling all beatdown records... Stand by...')
 


### PR DESCRIPTION
Bug: Using set literals (e.g., {'column1', 'column2'}) as the 'columns' parameter in pd.DataFrame() resulted in unpredictable column ordering.

Fix: Replace set literals with ordered lists (['column1', 'column2']) to ensure consistent and intended column order in DataFrames.

This change prevents potential data misalignment issues across various scripts that rely on specific column ordering in pandas DataFrames.